### PR TITLE
Don't watch events if deployment is already deleted

### DIFF
--- a/kelpy/deployment.py
+++ b/kelpy/deployment.py
@@ -91,14 +91,15 @@ def delete(client, name, namespace="default", wait_for_timeout=180):
             return False
         raise e
 
-    w = watch.Watch()
-    for event in w.stream(
-        client.list_deployment_for_all_namespaces, timeout_seconds=wait_for_timeout
-    ):
-        if (
-            event["type"] == "DELETED"
-            and event["object"].metadata.name == name
-            and event["object"].metadata.namespace == namespace
+    if get(client, name, namespace) is not None:
+        w = watch.Watch()
+        for event in w.stream(
+            client.list_deployment_for_all_namespaces, timeout_seconds=wait_for_timeout
         ):
-            break
+            if (
+                event["type"] == "DELETED"
+                and event["object"].metadata.name == name
+                and event["object"].metadata.namespace == namespace
+            ):
+                break
     return response


### PR DESCRIPTION
Prior to this change, kelpy will often block until the timeout is
reached since it will never get a DELETED even (because the deployment
will have already been deleted before the watch() started).

This scenario is suboptimal and slows down script and test execution
unnecessarily. By adding the if condition prior to the watch block, the
method will return immediately and avoid unnecessarily blocking.